### PR TITLE
Bugfix/invalid urls

### DIFF
--- a/scraper_v3/newschecker.py
+++ b/scraper_v3/newschecker.py
@@ -24,6 +24,7 @@ import requests
 import boto3
 
 import os
+import utils as scraper_v3_utils
 from dotenv import load_dotenv
 load_dotenv()
 
@@ -182,24 +183,11 @@ def crawler(crawl_url, lang_folder):
 
 
 def article_downloader(url, sub_folder): 
-    print("entered downloader")
-    print(url)
-
     file = "file.html"
     file_name = os.path.join(sub_folder, file)
     print(file_name)  
 
-    if os.path.exists(file_name):
-        print("Article Already Downloaded. Loading from local.")
-        with open(file_name, 'rb') as f:
-            html_text = f.read()
-    else:
-        response = requests.get(url)
-        html_text = response.content
-        with open(file_name, "wb") as f:
-            f.write(html_text)
-    
-    return html_text
+    return scraper_v3_utils.article_downloader(url, file_name)
 
 
 
@@ -489,6 +477,8 @@ def main():
             if not os.path.exists(sub_folder):
                 os.mkdir(sub_folder)
             html_text = article_downloader(link, sub_folder)
+            if not html_text:
+                continue
             post = article_parser(html_text, link, website.get("domain"), website.get("langs"), sub_folder)
             media_dict = media_downloader(post, sub_folder)
             data_uploader(post, media_dict, html_text, sub_folder)

--- a/scraper_v3/newschecker.py
+++ b/scraper_v3/newschecker.py
@@ -1,6 +1,8 @@
 ## Scraper Functions for Newsmeter
 ## 25 Feb 2021
 
+import logging
+import shutil
 from time import time, sleep
 from datetime import date, datetime
 from dateutil.parser import parse
@@ -122,6 +124,7 @@ def get_tree(url):
         html = requests.get(url)
     except Exception as e:
         print(f"failed request: {e}")
+        return None
 
     html.encoding = "utf-8"
     tree = fromstring(html.content)
@@ -371,7 +374,12 @@ def get_all_images(post,sub_folder):
             else:
                 filename = url.split("/")[-1]
                 
-                r = requests.get(url)
+                try:
+                    r = requests.get(url)
+                except requests.exceptions.ConnectionError as e:
+                    logging.exception(e)
+                    logging.error("Failed to download image %s", url)
+                    continue
                 try:
                     image = Image.open(BytesIO(r.content)) 
                     if len(filename.split(".")) == 1:

--- a/scraper_v3/scraper_boomlive.py
+++ b/scraper_v3/scraper_boomlive.py
@@ -1,6 +1,7 @@
 ## Scraper Functions for Boomlive
 ## 16 Feb 2021
 
+import logging
 from time import time, sleep
 from datetime import date, datetime
 from dateutil.parser import parse
@@ -434,7 +435,12 @@ def get_all_images(post,sub_folder):
                     url_split = url.split("uid=")
                     filename = url_split[1]
 
-                r = requests.get(url, headers=headers)
+                try:
+                    r = requests.get(url, headers=headers)
+                except requests.exceptions.ConnectionError as e:
+                    logging.exception(e)
+                    logging.error("Failed to download image %s", url)
+                    continue
                 image = Image.open(BytesIO(r.content)) 
                 if len(filename.split(".")) == 1:
                         # TODO: handle possible filename without extensions

--- a/scraper_v3/scraper_boomlive.py
+++ b/scraper_v3/scraper_boomlive.py
@@ -25,6 +25,7 @@ import boto3
 import os
 import shutil
 from dotenv import load_dotenv
+import utils as scraper_v3_utils
 load_dotenv()
 
 ## Decided: For Constants generate config file. Avoid domain specific functions in common config. 
@@ -193,23 +194,8 @@ def crawler(crawl_url, page_count, lang_folder) -> list:
 
 # ============================= ARTICLE DOWNLOADER BEGIN =======================
 def article_downloader(url, sub_folder): 
-    print("entered downloader")
-    print(url)
-    
-    # time_millis = int(time() * 1000)
     file_name = f'{sub_folder}story.html'
-
-    if os.path.exists(file_name):
-        print("Article Already Downloaded. Loading from local.")
-        with open(file_name, 'rb') as f:
-            html_text = f.read()
-    else:
-        response = requests.get(url, headers=headers)
-        html_text = response.content
-        with open(file_name, "wb") as f:
-            f.write(html_text)
-    
-    return html_text
+    return article_downloader(url, file_name)
 
     # response = requests.get(url, headers=headers)
 
@@ -570,6 +556,8 @@ def main():
             if not os.path.exists(sub_folder):
                 os.mkdir(sub_folder)
             html_text = article_downloader(link,sub_folder)
+            if not html_text:
+                continue
             post = article_parser(html_text, link,site.get("domain"),site.get("lang"),sub_folder)
             #import ipdb; ipdb.set_trace()
             media_items = media_downloader(post,sub_folder)

--- a/scraper_v3/scraper_digiteye.py
+++ b/scraper_v3/scraper_digiteye.py
@@ -1,6 +1,7 @@
 ## Scraper Functions for Digiteye
 ## 16 March 2021
 
+import logging
 from time import time, sleep
 from datetime import date, datetime
 from dateutil.parser import parse
@@ -439,7 +440,12 @@ def get_all_images(post,sub_folder):
                     url_split = url.split("uid=")
                     filename = url_split[1]
 
-                r = requests.get(url, headers=headers)
+                try:
+                    r = requests.get(url, headers=headers)
+                except requests.exceptions.ConnectionError as e:
+                    logging.exception(e)
+                    logging.error("Failed to download image %s", url)
+                    continue
                 image = Image.open(BytesIO(r.content)) 
                 if len(filename.split(".")) == 1:
                         # TODO: handle possible filename without extensions

--- a/scraper_v3/scraper_digiteye.py
+++ b/scraper_v3/scraper_digiteye.py
@@ -26,6 +26,7 @@ import boto3
 import os
 import shutil
 from dotenv import load_dotenv
+import utils as scraper_v3_utils
 load_dotenv()
 
 ## Decided: For Constants generate config file. Avoid domain specific functions in common config. 
@@ -183,23 +184,10 @@ def crawler(crawl_url, page_count, lang_folder) -> list:
 
 # ============================= ARTICLE DOWNLOADER BEGIN =======================
 def article_downloader(url, sub_folder): 
-    print("entered downloader")
-    print(url)
-    
     # time_millis = int(time() * 1000)
     file_name = f'{sub_folder}story.html'
 
-    if os.path.exists(file_name):
-        print("Article Already Downloaded. Loading from local.")
-        with open(file_name, 'rb') as f:
-            html_text = f.read()
-    else:
-        response = requests.get(url, headers=headers)
-        html_text = response.content
-        with open(file_name, "wb") as f:
-            f.write(html_text)
-    
-    return html_text
+    return article_downloader(url, file_name)
 
     # response = requests.get(url, headers=headers)
 
@@ -566,6 +554,8 @@ def main():
             if not os.path.exists(sub_folder):
                 os.mkdir(sub_folder)
             html_text = article_downloader(link,sub_folder)
+            if not html_text:
+                continue
             post = article_parser(html_text, link,site.get("domain"),site.get("lang"),sub_folder)
             #import ipdb; ipdb.set_trace()
             media_items = media_downloader(post,sub_folder)

--- a/scraper_v3/scraper_newschecker.py
+++ b/scraper_v3/scraper_newschecker.py
@@ -1,6 +1,8 @@
 ## Scraper Functions for Newschecker
 ## 7 Apr 2022
 
+import logging
+import shutil
 from time import time, sleep
 from datetime import date, datetime
 from dateutil.parser import parse
@@ -122,6 +124,7 @@ def get_tree(url):
         html = requests.get(url)
     except Exception as e:
         print(f"failed request: {e}")
+        return None
 
     html.encoding = "utf-8"
     tree = fromstring(html.content)
@@ -369,7 +372,12 @@ def get_all_images(post,sub_folder):
             else:
                 filename = url.split("/")[-1]
                 
-                r = requests.get(url)
+                try:
+                    r = requests.get(url)
+                except requests.exceptions.ConnectionError as e:
+                    logging.exception(e)
+                    logging.error("Failed to download image %s", url)
+                    continue
                 try:
                     image = Image.open(BytesIO(r.content)) 
                     if len(filename.split(".")) == 1:

--- a/scraper_v3/scraper_newschecker.py
+++ b/scraper_v3/scraper_newschecker.py
@@ -25,6 +25,7 @@ import boto3
 
 import os
 from dotenv import load_dotenv
+import utils as scraper_v3_utils
 load_dotenv()
 
 ## Decided: For Constants generate config file. Avoid domain specific functions in common config. 
@@ -182,24 +183,9 @@ def crawler(crawl_url, CRAWL_PAGE_COUNT, lang_folder) -> list:
 
 
 def article_downloader(url, sub_folder): 
-    print("entered downloader")
-    print(url)
-
     file_name = f'{sub_folder}story.html'
     #file_name = os.path.join(sub_folder, file)
-    print(file_name)  
-
-    if os.path.exists(file_name):
-        print("Article Already Downloaded. Loading from local.")
-        with open(file_name, 'rb') as f:
-            html_text = f.read()
-    else:
-        response = requests.get(url)
-        html_text = response.content
-        with open(file_name, "wb") as f:
-            f.write(html_text)
-    
-    return html_text
+    return article_downloader(url, file_name)
 
 
 
@@ -490,6 +476,8 @@ def main():
             if not os.path.exists(sub_folder):
                 os.mkdir(sub_folder)
             html_text = article_downloader(link, sub_folder)
+            if not html_text:
+                continue
             post = article_parser(html_text, link, site.get("domain"), site.get("langs"), sub_folder)
             media_dict = media_downloader(post, sub_folder)
             data_uploader(post, media_dict, html_text, sub_folder)

--- a/scraper_v3/scraper_newsmeter.py
+++ b/scraper_v3/scraper_newsmeter.py
@@ -24,6 +24,7 @@ import boto3
 
 import os
 from dotenv import load_dotenv
+import utils as scraper_v3_utils
 load_dotenv()
 
 ## Decided: For Constants generate config file. Avoid domain specific functions in common config. 
@@ -179,23 +180,10 @@ def crawler(crawl_url, page_count, lang_folder) -> list:
 
 # ============================= ARTICLE DOWNLOADER BEGIN =======================
 def article_downloader(url, sub_folder): 
-    print("entered downloader")
-    print(url)
-    
     # time_millis = int(time() * 1000)
     file_name = f'{sub_folder}story.html'
 
-    if os.path.exists(file_name):
-        print("Article Already Downloaded. Loading from local.")
-        with open(file_name, 'rb') as f:
-            html_text = f.read()
-    else:
-        response = requests.get(url, headers=headers)
-        html_text = response.content
-        with open(file_name, "wb") as f:
-            f.write(html_text)
-    
-    return html_text
+    return scraper_v3_utils.article_downloader(url, file_name)
 
 
 # ==============================================================================
@@ -548,6 +536,8 @@ def main():
             if not os.path.exists(sub_folder):
                 os.mkdir(sub_folder)
             html_text = article_downloader(link,sub_folder)
+            if not html_text:
+                continue
             post = article_parser(html_text, link,site.get("domain"),site.get("lang"),sub_folder)
             #import ipdb; ipdb.set_trace()
             media_items = media_downloader(post,sub_folder)

--- a/scraper_v3/scraper_newsmeter.py
+++ b/scraper_v3/scraper_newsmeter.py
@@ -1,6 +1,7 @@
 ## Scraper Functions for Newsmeter
 ## 25 Feb 2021
 
+import logging
 from time import time, sleep
 from datetime import date, datetime
 from dateutil.parser import parse
@@ -411,7 +412,12 @@ def get_all_images(post,sub_folder):
                     url_split = url.split("uid=")
                     filename = url_split[1]
 
-                r = requests.get(url, headers=headers)
+                try:
+                    r = requests.get(url, headers=headers)
+                except requests.exceptions.ConnectionError as e:
+                    logging.exception(e)
+                    logging.error("Failed to download image %s", url)
+                    continue
                 image = Image.open(BytesIO(r.content)) 
                 if len(filename.split(".")) == 1:
                         # TODO: handle possible filename without extensions

--- a/scraper_v3/scraper_tli.py
+++ b/scraper_v3/scraper_tli.py
@@ -25,6 +25,7 @@ import boto3
 import os
 import shutil
 from dotenv import load_dotenv
+import utils as scraper_v3_utils
 load_dotenv()
 
 ## Decided: For Constants generate config file. Avoid domain specific functions in common config. 
@@ -143,25 +144,9 @@ def crawler(crawl_url, page_count, lang_folder) -> list:
     return url_list
 
 def article_downloader(url, sub_folder): 
-    print("entered downloader")
-    print(url)
-    
-    
     file_name = f'{sub_folder}story.html'
     #file_name = os.path.join(sub_folder, file)
-    print(file_name)  
-
-    if os.path.exists(file_name):
-        print("Article Already Downloaded. Loading from local.")
-        with open(file_name, 'rb') as f:
-            html_text = f.read()
-    else:
-        response = requests.get(url)
-        html_text = response.content
-        with open(file_name, "wb") as f:
-            f.write(html_text)
-    
-    return html_text
+    return article_downloader(url, file_name)
 
 def get_article_info(pq):
 
@@ -445,6 +430,8 @@ def main():
             if not os.path.exists(sub_folder):
                 os.mkdir(sub_folder)
             html_text = article_downloader(link, sub_folder)
+            if not html_text:
+                continue
             post = article_parser(html_text, link,site.get("domain"),site.get("lang"),sub_folder)
             media_dict = media_downloader(post, sub_folder)
             data_uploader(post, media_dict, html_text, sub_folder)

--- a/scraper_v3/scraper_tli.py
+++ b/scraper_v3/scraper_tli.py
@@ -1,6 +1,7 @@
 ## Scraper Functions for The Logical Indian
 ## 7 April 2022
 
+import logging
 from time import time, sleep
 from datetime import date, datetime
 from dateutil.parser import parse
@@ -88,6 +89,7 @@ def get_tree(url):
         html = requests.get(url)
     except Exception as e:
         print(f"failed request: {e}")
+        return None
 
     html.encoding = "utf-8"
     tree = fromstring(html.content)
@@ -323,7 +325,12 @@ def get_all_images(post,sub_folder):
             else:
                 filename = url.split("/")[-1]
                 
-                r = requests.get(url)
+                try:
+                    r = requests.get(url)
+                except requests.exceptions.ConnectionError as e:
+                    logging.exception(e)
+                    logging.error("Failed to download image %s", url)
+                    continue
                 image = Image.open(BytesIO(r.content)) 
                 if len(filename.split(".")) == 1:
                         filename = f"{filename}.{image.format.lower()}"

--- a/scraper_v3/scraper_youturn.py
+++ b/scraper_v3/scraper_youturn.py
@@ -1,6 +1,7 @@
 ## Scraper Functions for youturn
 ## 8 April 2021
 
+import logging
 from time import time, sleep
 from datetime import date, datetime
 from dateutil.parser import parse
@@ -24,6 +25,7 @@ import boto3
 
 import os
 import shutil
+import utils as scraper_v3_utils
 from dotenv import load_dotenv
 load_dotenv()
 
@@ -91,6 +93,7 @@ def get_tree(url):
         html = requests.get(url)
     except Exception as e:
         print(f"failed request: {e}")
+        return
 
     html.encoding = "utf-8"
     tree = fromstring(html.content)
@@ -158,24 +161,10 @@ def crawler(crawl_url, page_count, lang_folder) -> list:
 
 
 def article_downloader(url, sub_folder): 
-    print("entered downloader")
-    print(url)
-
     file_name = f'{sub_folder}story.html'
     #file_name = os.path.join(sub_folder, file)
-    print(file_name)  
 
-    if os.path.exists(file_name):
-        print("Article Already Downloaded. Loading from local.")
-        with open(file_name, 'rb') as f:
-            html_text = f.read()
-    else:
-        response = requests.get(url)
-        html_text = response.content
-        with open(file_name, "wb") as f:
-            f.write(html_text)
-    
-    return html_text
+    return scraper_v3_utils.article_downloader(url, file_name)
 
 
 
@@ -368,7 +357,12 @@ def get_all_images(post,sub_folder):
             else:
                 filename = url.split("/")[-1]
                 
-                r = requests.get(url)
+                try:
+                    r = requests.get(url)
+                except Exception as e:
+                    logging.exception(e)
+                    logging.error(f"Image failed to download {url}")
+                    continue
                 image = Image.open(BytesIO(r.content)) 
                 if len(filename.split(".")) == 1:
                         filename = f"{filename}.{image.format.lower()}"
@@ -467,6 +461,8 @@ def main():
             if not os.path.exists(sub_folder):
                 os.mkdir(sub_folder)
             html_text = article_downloader(link, sub_folder)
+            if not html_text:
+                continue
             post = article_parser(html_text, link,site.get("domain"),site.get("lang"),sub_folder)
             media_dict = media_downloader(post, sub_folder)
             data_uploader(post, media_dict, html_text, sub_folder)

--- a/scraper_v3/utils.py
+++ b/scraper_v3/utils.py
@@ -1,0 +1,33 @@
+"""Utils for the scaper v3 files"""
+
+import logging
+import os
+import requests
+
+
+def article_downloader(url, file_name):
+    """If the file is present, it reads and returns the contents. If not, it
+    downloads the URL and saves it in `file_name` then returns the contents
+
+    Returns None and writes to the error log if the URl cannot be downloaded"""
+
+    print("entered downloader")
+    print(url)
+    print(file_name)
+    if os.path.exists(file_name):
+        print("Article Already Downloaded. Loading from local.")
+        with open(file_name, "rb") as thefile:
+            html_text = thefile.read()
+    else:
+        try:
+            response = requests.get(url)
+            assert response.status_code % 100 == 2
+            html_text = response.content
+        except (requests.exceptions.ConnectionError, AssertionError) as exc:
+            logging.exception(exc)
+            logging.error("Article failed to download %s", url)
+            return None
+        with open(file_name, "wb") as thefile:
+            thefile.write(html_text)
+
+    return html_text


### PR DESCRIPTION
Fixes tattle-made/factchecking-sites-scraper#52

### Here's what I did:

1. Did a recursive search for `url_list.json` (since the issue mentioned problems with invalid urls in this file)
2. Saw that only the files under the `scraper_v3` folder had that keyword in them
3. Wrapped all `requests.get` statements in all files under `scraper_v3` - to log an exception and return None (or `continue`, as per the use case) instead of breaking execution
4. Cleaned up the (newly added) code a bit

### Steps to test:

To store the error output (everything outputted by logging.error and logging.exception), [you can redirect pipes while running](https://www.baeldung.com/linux/pipes-redirection), for example:

```
python path/to/file.py --arg1=hello arg2 2> error_log.txt
```
(Replace `path/to/file.py` , `--arg1=hello` and `arg2` as needed. the `2>` is intentional)

This will still display STDOUT (print commands, etc) to console - and STDERR (errors) will get stored in the error_log.txt

To store the print statements to one file and errors to another file:

```
python path/to/file.py --arg1=hello arg2 1> log.txt 2> error_log.txt
```
(Replace `path/to/file.py` , `--arg1=hello` and `arg2` as needed. the `1>` and `2>` are intentional)

This will store STDOUT to `log.txt` and STDERR to `error_log.txt`

I was not able to test the scrapers as I don't have the data required to run the scrapers (urls, etc). I did do a pylint check for errors and resolved those and the code is super simple, so it should work as described above.